### PR TITLE
Schema/Output fields order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,10 @@ target/
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+# Idea IDE
 .idea/
 *.iml
+
+# MVN shade plugin
+dependency-reduced-pom.xml

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.class
+target/
 
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/

--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ Tools to generate data for testing
 
 ```
 Schema schema = new SchemaBuilder().fromResource("schema.json").build();
-Generator generator = new Generator();
+OneTimeGenerator generator = new OneTimeGenerator();
 generator.generate(schema);
+schema.getOutput();
 ```
 
 ## Value Providers
@@ -82,7 +83,7 @@ Write sql formatted data to file.
 
 Properties:
 * *file* - required, file to save data
-* *format* - one of csv, tsv, sv(require *deimiter* property), sql, es(require *index* property), default is csv
+* *format* - one of csv, tsv, sv (requires *delimiter* property, optionally also a boolean *header* property), sql, es (requires *index* property), default is csv
 
 Note: Be care with first three formats, they works well only with identically structured templates  
 

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.2</version>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <phase>never</phase>
@@ -110,7 +110,7 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
-                            <finalName>tdg</finalName>
+                            <finalName>tdg-shaded</finalName>
                             <transformers>
                                 <transformer
                                         implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">

--- a/src/main/java/com/presidentio/testdatagenerator/GenerateTask.java
+++ b/src/main/java/com/presidentio/testdatagenerator/GenerateTask.java
@@ -18,9 +18,8 @@ import com.presidentio.testdatagenerator.model.Field;
 import com.presidentio.testdatagenerator.model.Template;
 import com.presidentio.testdatagenerator.provider.ValueProvider;
 import com.presidentio.testdatagenerator.provider.ValueProviderFactory;
-
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.RecursiveAction;
@@ -42,7 +41,7 @@ public class GenerateTask extends RecursiveAction {
     private void generateEntity(final Context context, final Template template) {
         List<GenerateTask> forkJoinTasks = new ArrayList<>(template.getCount());
         for (int i = 0; i < template.getCount(); i++) {
-            Map<String, Object> entity = new HashMap<>();
+            Map<String, Object> entity = new LinkedHashMap<>();
             for (Field field : template.getFields()) {
                 ValueProvider valueProvider = valueProviderFactory.buildValueProvider(field.getProvider());
                 entity.put(field.getName(), valueProvider.nextValue(context, field));


### PR DESCRIPTION
Hi :smile: 
here's a first pull-request, which is mainly about this commit:

> 5e9a12e : Now the fields definition order in the json schema will be the same used to write to the output

The remaining commits are not so important (updating readme and .gitignore files)